### PR TITLE
Fix CI workflow, formatting, and GitHub org name

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: recursive
 
@@ -28,35 +28,44 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-    
+
     - name: Test with coverage
       run: go test -v ./... -coverprofile coverage.txt
-      
-      
+
     - name: Upload Coverage report to CodeCov
       uses: codecov/codecov-action@v1
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.txt
-  
-  imports:
-    name: goimports
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
-      with:
-        run: imports
-        token: ${{ secrets.GITHUB_TOKEN }}
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: check
-      uses: grandcolline/golang-github-actions@v1.1.0
-      with:
-        run: lint
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "^1.13"
+
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # goimports provides a superset of gofmt functionality
+      - run: goimports -w .
+
+      - name: Run go mod tidy on all modules
+        run: go mod tidy
+
+      # If there are any diffs from goimports or go mod tidy, fail.
+      - name: Verify no changes from goimports and go mod tidy.
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            # Show the files that failed to pass the check.
+            echo 'Lint check failed:'
+            git diff --minimal --compact-summary
+            echo 'To fix this check, run "goimports -w . && go mod tidy"'
+            exit 1
+          fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ion-tests"]
 	path = ion-tests
-	url = https://github.com/amzn/ion-tests.git
+	url = https://github.com/amazon-ion/ion-tests.git

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Amazon Ion Go
 
-[![Build Status](https://github.com/amzn/ion-go/workflows/Go%20Build/badge.svg)](https://github.com/amzn/ion-go/actions?query=workflow%3A%22Go+Build%22)
-[![license](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amzn/ion-go/blob/master/LICENSE)
-[![docs](https://img.shields.io/badge/docs-api-green.svg)](https://pkg.go.dev/github.com/amzn/ion-go?tab=doc)
+[![Build Status](https://github.com/amazon-ion/ion-go/workflows/Go%20Build/badge.svg)](https://github.com/amazon-ion/ion-go/actions?query=workflow%3A%22Go+Build%22)
+[![license](https://img.shields.io/hexpm/l/plug.svg)](https://github.com/amazon-ion/ion-go/blob/master/LICENSE)
+[![docs](https://img.shields.io/badge/docs-api-green.svg)](https://pkg.go.dev/github.com/amazon-ion/ion-go?tab=doc)
 
-Amazon Ion ( http://amzn.github.io/ion-docs/ ) library for Go
+Amazon Ion ( https://amazon-ion.github.io/ion-docs/ ) library for Go
 
-[Ion Cookbook](https://amzn.github.io/ion-docs/guides/cookbook.html) demonstrates code samples for some simple Amazon Ion use cases.
+[Ion Cookbook](https://amazon-ion.github.io/ion-docs/guides/cookbook.html) demonstrates code samples for some simple Amazon Ion use cases.
 
 This package is based on work from David Murray ([fernomac](https://github.com/fernomac/)) on https://github.com/fernomac/ion-go.
 The Ion team greatly appreciates David's contributions to the Ion community.
@@ -32,7 +32,7 @@ The easiest way to clone the `ion-go` repository and initialize its `ion-tests`
 submodule is to run the following command.
 
 ```
-$ git clone --recursive https://github.com/amzn/ion-go.git ion-go
+$ git clone --recursive https://github.com/amazon-ion/ion-go.git ion-go
 ```
 
 Alternatively, the submodule may be initialized independent of the clone
@@ -71,7 +71,7 @@ It is recommended that you hook this in your favorite IDE (`Tools` > `File Watch
 
 ## Usage
 
-Import `github.com/amzn/ion-go/ion` and you're off to the races.
+Import `github.com/amazon-ion/ion-go/ion` and you're off to the races.
 
 ### Marshaling and Unmarshaling
 

--- a/cmd/ion-go/eventwriter.go
+++ b/cmd/ion-go/eventwriter.go
@@ -21,7 +21,7 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/amzn/ion-go/ion"
+	"github.com/amazon-ion/ion-go/ion"
 )
 
 type eventwriter struct {

--- a/cmd/ion-go/main.go
+++ b/cmd/ion-go/main.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/amzn/ion-go/internal"
-	"github.com/amzn/ion-go/ion"
+	"github.com/amazon-ion/ion-go/internal"
+	"github.com/amazon-ion/ion-go/ion"
 )
 
 // main is the main entry point for ion-go.

--- a/cmd/ion-go/nopwriter.go
+++ b/cmd/ion-go/nopwriter.go
@@ -18,7 +18,7 @@ package main
 import (
 	"math/big"
 
-	"github.com/amzn/ion-go/ion"
+	"github.com/amazon-ion/ion-go/ion"
 )
 
 type nopwriter struct{}

--- a/cmd/ion-go/process.go
+++ b/cmd/ion-go/process.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/amzn/ion-go/ion"
+	"github.com/amazon-ion/ion-go/ion"
 )
 
 // process reads the specified input file(s) and re-writes the contents in the
@@ -83,7 +83,7 @@ func newProcessor(args []string) (*processor, error) {
 			}
 			ret.errf = args[i]
 
-		// https://github.com/amzn/ion-go/issues/121
+		// https://github.com/amazon-ion/ion-go/issues/121
 
 		default:
 			return nil, errors.New("unrecognized option \"" + arg + "\"")

--- a/cmd/ion-go/schema.go
+++ b/cmd/ion-go/schema.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/amzn/ion-go/ion"
+	"github.com/amazon-ion/ion-go/ion"
 )
 
 type importdescriptor struct {

--- a/cmd/ion-go/util.go
+++ b/cmd/ion-go/util.go
@@ -19,7 +19,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/amzn/ion-go/ion"
+	"github.com/amazon-ion/ion-go/ion"
 )
 
 type stdin struct{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/amzn/ion-go
+module github.com/amazon-ion/ion-go
 
 go 1.13
 

--- a/ion/binarywriter.go
+++ b/ion/binarywriter.go
@@ -559,7 +559,7 @@ func (w *binaryWriter) beginValue(api string) error {
 			buf = appendVarUint(buf, id)
 		}
 
-		// https://github.com/amzn/ion-go/issues/120
+		// https://github.com/amazon-ion/ion-go/issues/120
 		w.bufs.push(&container{code: 0xE0})
 		if err := w.write(buf); err != nil {
 			return err

--- a/ion/decimal.go
+++ b/ion/decimal.go
@@ -34,7 +34,7 @@ func (e *ParseError) Error() string {
 	return fmt.Sprintf("ion: ParseDecimal(%v): %v", e.Num, e.Msg)
 }
 
-// https://github.com/amzn/ion-go/issues/119
+// https://github.com/amazon-ion/ion-go/issues/119
 
 // Decimal is an arbitrary-precision decimal value.
 type Decimal struct {
@@ -198,7 +198,7 @@ func (d *Decimal) ShiftR(shift int) *Decimal {
 	}
 }
 
-// https://github.com/amzn/ion-go/issues/118
+// https://github.com/amazon-ion/ion-go/issues/118
 
 // Sign returns -1 if the value is less than 0, 0 if it is equal to zero,
 // and +1 if it is greater than zero.

--- a/ion/fields.go
+++ b/ion/fields.go
@@ -64,7 +64,7 @@ type fielder struct {
 }
 
 // FieldsFor returns the fields of the given struct type.
-// https://github.com/amzn/ion-go/issues/117
+// https://github.com/amazon-ion/ion-go/issues/117
 func fieldsFor(t reflect.Type) []field {
 	fldr := fielder{index: map[string]bool{}}
 	fldr.inspect(t, nil)

--- a/ion/integration_test.go
+++ b/ion/integration_test.go
@@ -111,7 +111,7 @@ var malformedIonsSkipList = []string{
 
 var equivsSkipList = []string{
 	"nonIVMNoOps.ion",
-	"stringUtf8.ion", // fails on utf-16 surrogate https://github.com/amzn/ion-go/issues/75
+	"stringUtf8.ion", // fails on utf-16 surrogate https://github.com/amazon-ion/ion-go/issues/75
 }
 
 var nonEquivsSkipList []string

--- a/ion/marshal.go
+++ b/ion/marshal.go
@@ -42,44 +42,42 @@ type Marshaler interface {
 //
 // Different Go types can be passed into MarshalText() to be marshalled to their corresponding Ion types. e.g.,
 //
-//     val, err := MarshalText(9)
-//     if err != nil {
-//         t.Fatal(err)
-//     }
-//     fmt.Println(string(val)) // prints out: 9
+//	    val, err := MarshalText(9)
+//	    if err != nil {
+//	        t.Fatal(err)
+//	    }
+//	    fmt.Println(string(val)) // prints out: 9
 //
-//	   type inner struct {
-//		   B int `ion:"b"`
-//	   }
-//	   type root struct {
-//		   A inner `ion:"a"`
-//		   C int `ion:"c"`
-//	   }
+//		   type inner struct {
+//			   B int `ion:"b"`
+//		   }
+//		   type root struct {
+//			   A inner `ion:"a"`
+//			   C int `ion:"c"`
+//		   }
 //
-//     v = root{A: inner{B: 6}, C: 7}
-//	   val, err = MarshalText(v)
-//	   if err != nil {
-//         t.Fatal(err)
-//     }
-//	   fmt.Println(string(val)) // prints out: {a:{b:6},c:7}
-//
+//	    v = root{A: inner{B: 6}, C: 7}
+//		   val, err = MarshalText(v)
+//		   if err != nil {
+//	        t.Fatal(err)
+//	    }
+//		   fmt.Println(string(val)) // prints out: {a:{b:6},c:7}
 //
 // Should the value for marshalling require annotations, it must be wrapped in a
 // Go struct with exactly 2 fields, where the other field of the struct is a slice of
 // string and tagged `ion:",annotations"`, and this field can carry all the desired
 // annotations.
 //
-//     type foo struct {
-//         Value   int
-//         AnyName []string `ion:",annotations"`
-//     }
+//	type foo struct {
+//	    Value   int
+//	    AnyName []string `ion:",annotations"`
+//	}
 //
-//     v := foo{5, []string{"some", "annotations"}}   //some::annotations::5
-//     val, err := MarshalText(v)
-//     if err != nil {
-//         t.Fatal(err)
-//     }
-//
+//	v := foo{5, []string{"some", "annotations"}}   //some::annotations::5
+//	val, err := MarshalText(v)
+//	if err != nil {
+//	    t.Fatal(err)
+//	}
 func MarshalText(v interface{}) ([]byte, error) {
 	buf := bytes.Buffer{}
 	w := NewTextWriterOpts(&buf, TextWriterQuietFinish)

--- a/ion/marshal.go
+++ b/ion/marshal.go
@@ -303,7 +303,7 @@ func keysFor(v reflect.Value) []mapkey {
 	res := make([]mapkey, len(keys))
 
 	for i, key := range keys {
-		// https://github.com/amzn/ion-go/issues/116
+		// https://github.com/amazon-ion/ion-go/issues/116
 		if key.Kind() != reflect.String {
 			panic("unexpected map key type")
 		}

--- a/ion/reader.go
+++ b/ion/reader.go
@@ -33,10 +33,10 @@ import (
 // Next moves the Reader to the position after the final value in the stream, it returns
 // false, making it easy to loop through the values in a stream.
 //
-// 	var r Reader
-// 	for r.Next() {
-// 		// ...
-// 	}
+//	var r Reader
+//	for r.Next() {
+//		// ...
+//	}
 //
 // Next also returns false in case of error. This can be distinguished from a legitimate
 // end-of-stream by calling Err after exiting the loop.
@@ -56,22 +56,21 @@ import (
 // outer sequence of values. The Reader will be positioned at the end of the composite value,
 // such that a call to Next will move to the immediately-following value (if any).
 //
-// 	r := NewTextReaderStr("[foo, bar] [baz]")
-// 	for r.Next() {
-// 		if err := r.StepIn(); err != nil {
-// 			return err
-// 		}
-// 		for r.Next() {
-// 			fmt.Println(r.StringValue())
-// 		}
-// 		if err := r.StepOut(); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	if err := r.Err(); err != nil {
-// 		return err
-// 	}
-//
+//	r := NewTextReaderStr("[foo, bar] [baz]")
+//	for r.Next() {
+//		if err := r.StepIn(); err != nil {
+//			return err
+//		}
+//		for r.Next() {
+//			fmt.Println(r.StringValue())
+//		}
+//		if err := r.StepOut(); err != nil {
+//			return err
+//		}
+//	}
+//	if err := r.Err(); err != nil {
+//		return err
+//	}
 type Reader interface {
 	// Next advances the Reader to the next position in the current value stream.
 	// It returns true if this is the position of an Ion value, and false if it

--- a/ion/skipper.go
+++ b/ion/skipper.go
@@ -67,9 +67,8 @@ func (t *tokenizer) SkipDot() (bool, error) {
 	return true, nil
 }
 
-// SkipLobWhitespace skips whitespace when we're inside a large
-// object ({{  ///=  }} or {{ '''///=''' }}) where comments are
-// not allowed.
+// SkipLobWhitespace skips whitespace when we're inside a blob
+// or clob where comments are not allowed.
 func (t *tokenizer) SkipLobWhitespace() (int, error) {
 	c, _, err := t.skipLobWhitespace()
 	return c, err
@@ -502,8 +501,8 @@ func (t *tokenizer) skipStringHelper() error {
 	}
 }
 
-// SkipLongString skips over a '''-enclosed string, returning the next
-// character after the closing '''.
+// SkipLongString skips over a triple-quote-enclosed string, returning the next
+// character after the closing triple-quote.
 func (t *tokenizer) skipLongString() (int, error) {
 	if err := t.skipLongStringHelper(t.skipCommentsHandler); err != nil {
 		return 0, err
@@ -511,7 +510,7 @@ func (t *tokenizer) skipLongString() (int, error) {
 	return t.read()
 }
 
-// SkipLongStringHelper skips over a '''-enclosed string.
+// SkipLongStringHelper skips over a triple-quote-enclosed string.
 func (t *tokenizer) skipLongStringHelper(handler commentHandler) error {
 	for {
 		c, err := t.read()
@@ -544,7 +543,7 @@ func (t *tokenizer) skipLongStringHelper(handler commentHandler) error {
 // of the long string, and if we have consumed any ' characters. Also, it can detect
 // if another long string starts after the current one; in that case, it returns
 // false indicating this is not the end of the long string, and true for consumed '
-// as we have read the closing ''' of the first long string.
+// as we have read the closing triple-quote of the first long string.
 func (t *tokenizer) skipEndOfLongString(handler commentHandler) (bool, bool, error) {
 	isConsumed := false
 	// We just read a ', check for two more ''s.
@@ -756,9 +755,8 @@ func (t *tokenizer) skipWhitespaceHelper() (bool, error) {
 	return ok, err
 }
 
-// SkipLobWhitespace skips whitespace when we're inside a large
-// object ({{  ///=  }} or {{ '''///=''' }}) where comments are
-// not allowed.
+// SkipLobWhitespace skips whitespace when we're inside a blob
+// or clob, where comments are not allowed.
 func (t *tokenizer) skipLobWhitespace() (int, bool, error) {
 	// Comments are not allowed inside a lob value; if we see a '/',
 	// it's the start of a base64-encoded value.

--- a/ion/skipper.go
+++ b/ion/skipper.go
@@ -602,7 +602,7 @@ func (t *tokenizer) skipBlobHelper() error {
 		return err
 	}
 
-	// https://github.com/amzn/ion-go/issues/115
+	// https://github.com/amazon-ion/ion-go/issues/115
 	for c != '}' {
 		c, _, err = t.skipLobWhitespace()
 		if err != nil {

--- a/ion/tokenizer.go
+++ b/ion/tokenizer.go
@@ -1161,7 +1161,9 @@ func (t *tokenizer) ReadLongClob() ([]byte, error) {
 	return val, nil
 }
 
-// IsTripleQuote returns true if this is a triple-quote sequence (''').
+// IsTripleQuote returns true if this is a triple-quote sequence; i.e.:
+//
+//	'''
 func (t *tokenizer) IsTripleQuote() (bool, error) {
 	// We've just read a '\'', check if the next two are too.
 	cs, err := t.peekN(2)

--- a/ion/unmarshal.go
+++ b/ion/unmarshal.go
@@ -48,20 +48,19 @@ type Unmarshaler interface {
 // User must pass the proper object type to the unmarshalled Ion data.
 // Below is the mapping between Go native type and Ion types. e.g.,
 //
-//     boolBytes := []byte{0xE0, 0x01, 0x00, 0xEA, 0x11}
-//     var boolVal bool
-//     err := Unmarshal(boolBytes, &boolVal)
-//     if err != nil {
-//         t.Fatal(err)
-//     }
-//     fmt.Println(boolVal) // prints out: true
+//	    boolBytes := []byte{0xE0, 0x01, 0x00, 0xEA, 0x11}
+//	    var boolVal bool
+//	    err := Unmarshal(boolBytes, &boolVal)
+//	    if err != nil {
+//	        t.Fatal(err)
+//	    }
+//	    fmt.Println(boolVal) // prints out: true
 //
-//     err = UnmarshalString("true", &boolVal)
-//     if err != nil {
-//         t.Fatal(err)
-//     }
-//     fmt.Println(boolVal) // prints out: true
-//
+//		err = UnmarshalString("true", &boolVal)
+//		if err != nil {
+//		    t.Fatal(err)
+//		}
+//		fmt.Println(boolVal) // prints out: true
 //
 // To unmarshal an Ion value with annotations, the object passed to Unmarshal
 // must be a Go struct with exactly two fields, where one field's type
@@ -69,34 +68,33 @@ type Unmarshaler interface {
 // of mapping between Go native types and Ion types below); and the other
 // field must be of type []string and tagged as `ion:",annotations"`.
 //
-//     type foo struct {
-//         Value   int    // or interface{}
-//         AnyName []string `ion:",annotations"`
-//     }
+//	  type foo struct {
+//	      Value   int    // or interface{}
+//	      AnyName []string `ion:",annotations"`
+//	  }
 //
-//     var val foo
-//     err := UnmarshalString("age::10", &val)
-//     if err != nil {
-//         t.Fatal(err)
-//     }
-//     fmt.Println(val) // prints out: {10 [age]}
+//	  var val foo
+//	  err := UnmarshalString("age::10", &val)
+//	  if err != nil {
+//	      t.Fatal(err)
+//	  }
+//	  fmt.Println(val) // prints out: {10 [age]}
 //
-//     Go native type                                  Ion Type
-//   --------------------------                     ---------------
-//     nil/interface{}                                 null
-//     bool/interface{}                                bool
-//     Any ints/uints/big.Int/interface{}              int
-//     float32/float64/interface{}                     float
-//     ion.Decimal/interface{}                         decimal
-//     ion.Timestamp/interface{}                       timestamp
-//     string/interface{}                              symbol
-//     string/interface{}                              string
-//     []byte/[]interface{}{}                          clob
-//     []byte/[]interface{}{}                          blob
-//     []interface{}{}                                 list
-//     []interface{}{}                                 sexp
-//     map[string]interface{}{}/struct/interface{}     struct
-//
+//	  Go native type                                  Ion Type
+//	--------------------------                     ---------------
+//	  nil/interface{}                                 null
+//	  bool/interface{}                                bool
+//	  Any ints/uints/big.Int/interface{}              int
+//	  float32/float64/interface{}                     float
+//	  ion.Decimal/interface{}                         decimal
+//	  ion.Timestamp/interface{}                       timestamp
+//	  string/interface{}                              symbol
+//	  string/interface{}                              string
+//	  []byte/[]interface{}{}                          clob
+//	  []byte/[]interface{}{}                          blob
+//	  []interface{}{}                                 list
+//	  []interface{}{}                                 sexp
+//	  map[string]interface{}{}/struct/interface{}     struct
 func Unmarshal(data []byte, v interface{}, ssts ...SharedSymbolTable) error {
 	catalog := NewCatalog(ssts...)
 	return NewDecoder(NewReaderCat(bytes.NewReader(data), catalog)).DecodeTo(v)

--- a/ion/unmarshal_test.go
+++ b/ion/unmarshal_test.go
@@ -647,7 +647,7 @@ func TestDecode(t *testing.T) {
 }
 
 func TestDecodeLotsOfInts(t *testing.T) {
-	// Regression test for https://github.com/amzn/ion-go/issues/53
+	// Regression test for https://github.com/amazon-ion/ion-go/issues/53
 	buf := bytes.Buffer{}
 	w := NewBinaryWriter(&buf)
 	for i := 0; i < 512; i++ {

--- a/ion/writer.go
+++ b/ion/writer.go
@@ -27,29 +27,29 @@ import (
 // calls to Write will write values inside of the container until a matching
 // End method is called.
 //
-// 	var w Writer
-// 	w.BeginSexp()
-// 	{
-// 		w.WriteInt(1)
-// 		w.WriteSymbolFromString("+")
-// 		w.WriteInt(1)
-// 	}
-// 	w.EndSexp()
+//	var w Writer
+//	w.BeginSexp()
+//	{
+//		w.WriteInt(1)
+//		w.WriteSymbolFromString("+")
+//		w.WriteInt(1)
+//	}
+//	w.EndSexp()
 //
 // When writing values inside a struct, the FieldName method must be called before
 // each value to set the value's field name. The Annotation method may likewise
 // be called before writing any value to add an annotation to the value.
 //
-// 	var w Writer
-// 	w.Annotation("user")
-// 	w.BeginStruct()
-// 	{
-// 		w.FieldName("id")
-// 		w.WriteString("foo")
-// 		w.FieldName("name")
-// 		w.WriteString("bar")
-// 	}
-// 	w.EndStruct()
+//	var w Writer
+//	w.Annotation("user")
+//	w.BeginStruct()
+//	{
+//		w.FieldName("id")
+//		w.WriteString("foo")
+//		w.FieldName("name")
+//		w.WriteString("bar")
+//	}
+//	w.EndStruct()
 //
 // When you're done writing values, you should call Finish to ensure everything has
 // been flushed from in-memory buffers. While individual methods all return an error
@@ -57,12 +57,11 @@ import (
 // return the previous error. This lets you keep code a bit cleaner by only checking
 // the return value of the final method call (generally Finish).
 //
-// 	var w Writer
-// 	writeSomeStuff(w)
-// 	if err := w.Finish(); err != nil {
-// 		return err
-// 	}
-//
+//	var w Writer
+//	writeSomeStuff(w)
+//	if err := w.Finish(); err != nil {
+//		return err
+//	}
 type Writer interface {
 	// FieldName sets the field name for the next value written.
 	FieldName(val SymbolToken) error

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,8 +6,8 @@ export COMMIT=$(git rev-parse --short HEAD 2> /dev/null)
 export BUILDTIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 export LDFLAGS="\
-    -X \"github.com/amzn/ion-go/internal.GitCommit=${COMMIT}\" \
-    -X \"github.com/amzn/ion-go/internal.BuildTime=${BUILDTIME}\" \
+    -X \"github.com/amazon-ion/ion-go/internal.GitCommit=${COMMIT}\" \
+    -X \"github.com/amazon-ion/ion-go/internal.BuildTime=${BUILDTIME}\" \
     ${LDFLAGS:-}"
 
 go build -o ion-go --ldflags "${LDFLAGS}" ./cmd/ion-go

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,8 +6,8 @@ export COMMIT=$(git rev-parse --short HEAD 2> /dev/null)
 export BUILDTIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 export LDFLAGS="\
-    -X \"github.com/amzn/ion-go/internal.GitCommit=${COMMIT}\" \
-    -X \"github.com/amzn/ion-go/internal.BuildTime=${BUILDTIME}\" \
+    -X \"github.com/amazon-ion/ion-go/internal.GitCommit=${COMMIT}\" \
+    -X \"github.com/amazon-ion/ion-go/internal.BuildTime=${BUILDTIME}\" \
     ${LDFLAGS:-}"
 
 go install --ldflags "${LDFLAGS}" ./cmd/ion-go


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

There are 3 commits:
* Changes `amzn` to `amazon-ion` in links
* Replaces a broken github action that we were using with a new lint check that works
  * Example of the new lint check failing: https://github.com/popematt/ion-go/actions/runs/4067936206/jobs/7005874857d
  * Updated `actions/checkout` to v3 while I was at it, and cleaned up some extraneous whitespace in the workflow file.
* Fixes all of the formatting issues
  * For some unknown reason, `gofmt`/`goimports` things that `'''` must be replaced by `”'` in all Godoc comments, so I reworded most comments to avoid having `'''`, except for the function that is specifically for recognizing `'''`, where I added a code block to contain the `'''`.
  * All of the remaining changes were done automatically by `goimports`, and they are all replacing spaces with tabs and/or moving blank lines in the Godoc comments.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

