### PR TITLE
Fix math/big.Int Does not Marshal

### DIFF
--- a/ion/marshal.go
+++ b/ion/marshal.go
@@ -384,6 +384,9 @@ func (m *Encoder) encodeStruct(v reflect.Value) error {
 	if t == decimalType {
 		return m.encodeDecimal(v)
 	}
+	if t == bigIntType {
+		return m.encodeBigInt(v)
+	}
 
 	if err := m.w.BeginStruct(); err != nil {
 		return err
@@ -445,10 +448,16 @@ func (m *Encoder) encodeTimeDate(v reflect.Value) error {
 	return m.w.WriteTimestamp(timestamp)
 }
 
-// EncodeDecimal encodes an ion.Decimal to the output writer as an Ion decimal.
+// encodeDecimal encodes an ion.Decimal to the output writer as an Ion decimal.
 func (m *Encoder) encodeDecimal(v reflect.Value) error {
 	d := v.Addr().Interface().(*Decimal)
 	return m.w.WriteDecimal(d)
+}
+
+// encodeBigInt encodes a math/big.Int to the output writer as a big.Int.
+func (m *Encoder) encodeBigInt(v reflect.Value) error {
+	b := v.Addr().Interface().(*big.Int)
+	return m.w.WriteBigInt(b)
 }
 
 func (m *Encoder) encodeWithAnnotation(v reflect.Value, fields []field) error {

--- a/ion/marshal_test.go
+++ b/ion/marshal_test.go
@@ -18,6 +18,7 @@ package ion
 import (
 	"bytes"
 	"math"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
@@ -42,6 +43,10 @@ func TestMarshalText(t *testing.T) {
 	test(byte(42), "42")
 	test(-42, "-42")
 	test(uint64(math.MaxUint64), "18446744073709551615")
+	bigIntPos, _ := new(big.Int).SetString("123456789012345678901234567890", 10)
+	test(bigIntPos, "123456789012345678901234567890")
+	bigIntNeg, _ := new(big.Int).SetString("-123456789012345678901234567890", 10)
+	test(bigIntNeg, "-123456789012345678901234567890")
 	test(math.MinInt64, "-9223372036854775808")
 
 	test(42.0, "4.2e+1")

--- a/ion/type.go
+++ b/ion/type.go
@@ -39,9 +39,6 @@ const (
 	// DecimalType is the type of an arbitrary-precision Ion decimal value.
 	DecimalType
 
-	// BigIntType is the type of a multi-precision integer value.
-	BigIntType
-
 	// TimestampType is the type of an arbitrary-precision Ion timestamp.
 	TimestampType
 
@@ -103,8 +100,6 @@ func (t Type) String() string {
 		return "list"
 	case SexpType:
 		return "sexp"
-	case BigIntType:
-		return "bigint"
 	default:
 		return fmt.Sprintf("<unknown type %v>", uint8(t))
 	}

--- a/ion/type.go
+++ b/ion/type.go
@@ -39,6 +39,9 @@ const (
 	// DecimalType is the type of an arbitrary-precision Ion decimal value.
 	DecimalType
 
+	// BigIntType is the type of a multi-precision integer value.
+	BigIntType
+
 	// TimestampType is the type of an arbitrary-precision Ion timestamp.
 	TimestampType
 
@@ -100,6 +103,8 @@ func (t Type) String() string {
 		return "list"
 	case SexpType:
 		return "sexp"
+	case BigIntType:
+		return "bigint"
 	default:
 		return fmt.Sprintf("<unknown type %v>", uint8(t))
 	}


### PR DESCRIPTION
This is intended to be a fix for https://github.com/amazon-ion/ion-go/issues/193. ion.MarshalText() returns "{}" for math/big.Int values.

Added BigIntType in type.go. Created func encodeBigInt() in marshal.go and added it to encodeStruct(). Also added unit tests for math/big.Int in marshal_test.go.