### PR TITLE
Add Reset function to binaryReader

### DIFF
--- a/ion/binaryreader.go
+++ b/ion/binaryreader.go
@@ -51,6 +51,9 @@ func newBinaryReaderBuf(in *bufio.Reader, cat Catalog) Reader {
 // reuse a binaryReader with inconsistent input bytes will cause the reader
 // to return errors, misappropriate values to unrelated or non-existent
 // attributes, or incorrectly parse data values.
+//
+// This API is experimental and should be considered unstable.
+// See https://github.com/amazon-ion/ion-go/pull/196
 func (r *binaryReader) Reset(in []byte) error {
 	if r.resetPos == invalidReset {
 		return &UsageError{"binaryReader.Reset", "cannot reset when multiple local symbol tables found"}


### PR DESCRIPTION
Reset improves reader performance when the same binary data is processed multiple times. It works by reusing the symbol table constructed during the first read, and jumping straight to the first "content" byte when Reset is called.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.